### PR TITLE
Office 365 Analysis: Plugin has testing version 1.0.0-release causing import to fail

### DIFF
--- a/workflows/Office_365_Analysis/Office_365_Analysis.icon
+++ b/workflows/Office_365_Analysis/Office_365_Analysis.icon
@@ -532,7 +532,7 @@
               "name": "Storage",
               "slugVendor": "rapid7",
               "slugName": "storage",
-              "slugVersion": "1.0.0-release",
+              "slugVersion": "1.0.0",
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/step-type-icons/default.svg"
             },
             "identifier": "store",
@@ -1831,7 +1831,7 @@
               "name": "Storage",
               "slugVendor": "rapid7",
               "slugName": "storage",
-              "slugVersion": "1.0.0-release",
+              "slugVersion": "1.0.0,
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/step-type-icons/default.svg"
             },
             "identifier": "store",
@@ -1954,7 +1954,7 @@
               "name": "Storage",
               "slugVendor": "rapid7",
               "slugName": "storage",
-              "slugVersion": "1.0.0-release",
+              "slugVersion": "1.0.0",
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/step-type-icons/default.svg"
             },
             "identifier": "store",
@@ -2043,7 +2043,7 @@
               "name": "Storage",
               "slugVendor": "rapid7",
               "slugName": "storage",
-              "slugVersion": "1.0.0-release",
+              "slugVersion": "1.0.0",
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/step-type-icons/default.svg"
             },
             "identifier": "retrieve",
@@ -2390,7 +2390,7 @@
               "name": "Storage",
               "slugVendor": "rapid7",
               "slugName": "storage",
-              "slugVersion": "1.0.0-release",
+              "slugVersion": "1.0.0",
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/step-type-icons/default.svg"
             },
             "identifier": "retrieve",


### PR DESCRIPTION
* Fixed slugVersion in workflow's Storage plugin
* Still getting the following error after - @jmcadams-r7 need you to fix. Did you export this from ICON?

<img width="1584" alt="Screen Shot 2019-09-24 at 6 50 47 PM" src="https://user-images.githubusercontent.com/30870727/65558512-b0274800-defc-11e9-9828-fcb3ff1a1ebe.png">
