### PR TITLE
Hub: Product key is an array, make plural

### DIFF
--- a/workflows/Automated_Indicator_Enrichment/workflow.spec.yaml
+++ b/workflows/Automated_Indicator_Enrichment/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Automated_Indicator_Enrichment
 title: "Automated Indicator Enrichment"
 description: "This workflow triggers from directly slack messaging the chatbot to \"!investigate\" the defined indicator. To date, this workflow supports automatically looking up URLs and IPs in open source threat intelligence such as VirusTotal and Whois. Lastly, the workflow will post back results to the specific user."

--- a/workflows/InsightIDR_Create_Incident_Report_in_ServiceNow/workflow.spec.yaml
+++ b/workflows/InsightIDR_Create_Incident_Report_in_ServiceNow/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Create_Incident_Report_in_ServiceNow
 title: "InsightIDR Create Incident Report in ServiceNow"
 description: "This workflow creates an incident report in ServiceNow."

--- a/workflows/InsightIDR_Create_Issue_in_Jira/workflow.spec.yaml
+++ b/workflows/InsightIDR_Create_Issue_in_Jira/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Create_Issue_in_Jira
 title: "InsightIDR Create Issue in Jira"
 description: "This workflow creates an issue in Jira from a triggered incident from InsightIDR"

--- a/workflows/InsightIDR_Disable_User_in_Active_Directory/workflow.spec.yaml
+++ b/workflows/InsightIDR_Disable_User_in_Active_Directory/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Disable_User_in_Active_Directory
 title: "InsightIDR Disable User in Active Directory"
 description: "Disable user in Active Directory from a triggered alert in InsightIDR"

--- a/workflows/InsightIDR_Enable_User_in_Active_Directory/workflow.spec.yaml
+++ b/workflows/InsightIDR_Enable_User_in_Active_Directory/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Enable_User_in_Active_Directory
 title: "InsightIDR Enable User in Active Directory"
 description: "Enable user in Active Directory from an Insight IDR alert"

--- a/workflows/InsightIDR_Enrich_Alert_Data_with_Open_Source_Plugins/workflow.spec.yaml
+++ b/workflows/InsightIDR_Enrich_Alert_Data_with_Open_Source_Plugins/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Enrich_Alert_Data_with_Open_Source_Plugins
 title: "InsightIDR Enrich Alert Data with Open Source Plugins"
 description: "Workflow that attempts to enrich all following IoCs (IPs, Domains, URLs, Hashes), if available. It can be associated with almost any alert."

--- a/workflows/InsightIDR_Isolate_Sensor_in_Cb_Response/workflow.spec.yaml
+++ b/workflows/InsightIDR_Isolate_Sensor_in_Cb_Response/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Isolate_Sensor_in_Cb_Response
 title: "InsightIDR Isolate Sensor in Cb Response"
 description: "This workflow isolates a sensor in Carbon Black Response from an event in InsightIDR."

--- a/workflows/InsightIDR_Suspend_User_in_Okta/workflow.spec.yaml
+++ b/workflows/InsightIDR_Suspend_User_in_Okta/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Suspend_User_in_Okta
 title: "InsightIDR Suspend User in Okta"
 description: "This workflow suspends a user in Okta from an event in InsightIDR."

--- a/workflows/InsightIDR_Unisolate_Sensor_in_Cb_Response/workflow.spec.yaml
+++ b/workflows/InsightIDR_Unisolate_Sensor_in_Cb_Response/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Unisolate_Sensor_in_Cb_Response
 title: "InsightIDR Unisolate Sensor in Cb Response"
 description: "This workflow enriches an IDR alert by performing a lookup on all hashes in the investigation with Recorded Future."

--- a/workflows/InsightIDR_Unsuspend_User_in_Okta/workflow.spec.yaml
+++ b/workflows/InsightIDR_Unsuspend_User_in_Okta/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: [insightconnect, insightidr]
+products: [insightconnect, insightidr]
 name: InsightIDR_Unsuspend_User_in_Okta
 title: "InsightIDR Unsuspend User in Okta"
 description: "This workflow removes a user from suspension in Okta from an event in InsightIDR."

--- a/workflows/Look_Up_Domains_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_Domains_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Look_Up_Domains_with_Recorded_Future
 title: "Look Up Domains with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all domains in the investigation with Recorded Future."

--- a/workflows/Look_Up_Hashes_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_Hashes_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Look_Up_Hashes_with_Recorded_Future
 title: "Look Up Hashes with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all hashes in the investigation with Recorded Future."

--- a/workflows/Look_Up_IPs_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_IPs_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Look_Up_IPs_with_Recorded_Future
 title: "Look Up IPs with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all IPs in the investigation with Recorded Future."

--- a/workflows/Look_Up_URLs_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_URLs_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Look Up URLs with Recorded Future
 title: "Look Up URLs with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all URLs in the investigation with Recorded Future."

--- a/workflows/Malicious_Hash_Remediation_with_Cb_Response/workflow.spec.yaml
+++ b/workflows/Malicious_Hash_Remediation_with_Cb_Response/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Malicious_Hash_Remediation_with_Cb_Response
 title: "Malicious Hash Remediation with Cb Response"
 description: "This workflow triggers off of InsightIDR's Malicious Hash on Asset alerts and does a lookup of the hash with Team Cymru before banning it with Cb Response"

--- a/workflows/Microsoft_Teams_URL_Analysis/workflow.spec.yaml
+++ b/workflows/Microsoft_Teams_URL_Analysis/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Microsoft_Teams_URL_Analysis
 title: "Microsoft Teams URL Analysis"
 description: "This workflow will scan a Microsoft Teams channel for `!check_url http://example.url`. When the workflow dectects a message matching that signature, it will automatically scan the URL in VirusTotal and return the results to Microsoft Teams."

--- a/workflows/Office_365_Analysis/workflow.spec.yaml
+++ b/workflows/Office_365_Analysis/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Office_365_Analysis
 title: "Office 365 Analysis"
 description: "This workflow is designed to automatically analyze incoming emails to determine if they are malicious. This workflow assumes a user is using their report phishing button to send an email to an administrative account with the suspicious email attached. The workflow will then analyze any URLs or files in the attached email to find malicious links. If any malicious indicators are found the email will be remediated across the organization."

--- a/workflows/Office_365_Analysis_with_Palo_Alto_Wildfire/workflow.spec.yaml
+++ b/workflows/Office_365_Analysis_with_Palo_Alto_Wildfire/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Office_365_Analysis_with_Palo_Alto_Wildfire
 title: "Office 365 Analysis with Palo Alto Wildfire"
 description: "This workflow is designed to automatically analyze incoming emails to determine if they are malicious. This workflow assumes a user is using their report phishing button to send an email to an administrative account with the suspicious email attached. The workflow will then analyze any URLs or files in the attached email to find malicious links. If any malicious indicators are found the email will be remediated across the organization."

--- a/workflows/Office_365_Analysis_with_Virus_Total/workflow.spec.yaml
+++ b/workflows/Office_365_Analysis_with_Virus_Total/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Office_365_Analysis_with_Virus_Total
 title: "Office 365 Analysis with Virus Total"
 description: "This workflow is designed to automatically analyze incoming emails to determine if they are malicious. This workflow assumes a user is using their report phishing button to send an email to an administrative account with the suspicious email attached. The workflow will then analyze any URLs or files in the attached email to find malicious links. If any malicious indicators are found the email will be remediated across the organization."

--- a/workflows/Spearphishing_Remediation_with_Mimecast/workflow.spec.yaml
+++ b/workflows/Spearphishing_Remediation_with_Mimecast/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Spearphishing_Remediation_with_Mimecast
 title: "Spearphishing Remediation with Mimecast"
 description: "IDR provides built-in machine learning based detections of spearphishing attempts through DNS queries to spoofed domains. On alert generation, this workflow automatically blocks a sender and creates a managed URL in Mimecast."

--- a/workflows/Spearphishing_Remediation_with_Office_365/workflow.spec.yaml
+++ b/workflows/Spearphishing_Remediation_with_Office_365/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Spearphishing_Remediation_with_Office_365
 title: "Spearphishing Remediation with Office 365"
 description: "IDR provides built-in machine learning based detections of spearphishing attempts through DNS queries to spoofed domains. On alert generation, this workflow automatically deletes true positive phishing emails across all user inboxes, and also immediately creates a block domain transport rule in Office365 Security & Compliance Center."

--- a/workflows/Splunk_App_SSH_Alert_IP_Enrichment/workflow.spec.yaml
+++ b/workflows/Splunk_App_SSH_Alert_IP_Enrichment/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-product: ["insightconnect"]
+products: ["insightconnect"]
 name: Splunk_App_SSH_Alert_IP_Enrichment
 title: "Splunk App SSH Alert IP Enrichment"
 description: "Receives an event sent by the Rapid7 InsightConnect App for Splunk and performs enrichment"


### PR DESCRIPTION
## Proposed Changes

Describe the proposed changes:

  - Make `product` key plural because it's an array

## Testing

```
$ for i in workflows/*/workflow.spec.yaml; do js-yaml $i 1>/dev/null || printf "Failure for $i\n"; done && printf "Complete";
Complete
```