### PR TITLE
Hub: Tags: Remove tags from workflow specs

### DIFF
--- a/workflows/Automated_Indicator_Enrichment/workflow.spec.yaml
+++ b/workflows/Automated_Indicator_Enrichment/workflow.spec.yaml
@@ -7,11 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- enrichment
-- slack
-- url
-- ip
 hub_tags:
   use_cases: [soar, soc_automation, chat_ops, alerting_and_notifications, threat_detection_and_response]
   keywords: [enrichment, slack, url, ip]

--- a/workflows/InsightIDR_Create_Incident_Report_in_ServiceNow/workflow.spec.yaml
+++ b/workflows/InsightIDR_Create_Incident_Report_in_ServiceNow/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- servicenow
-- ticket
-- insightidr
 hub_tags:
   use_cases: [soar, soc_automation, remediation_ticketing, threat_detection_and_response]
   keywords: [servicenow, ticket, insightidr]

--- a/workflows/InsightIDR_Create_Issue_in_Jira/workflow.spec.yaml
+++ b/workflows/InsightIDR_Create_Issue_in_Jira/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- ticketing
-- insightidr
-- jira
 hub_tags:
   use_cases: [soar, soc_automation, remediation_ticketing, threat_detection_and_response]
   keywords: [jira, insightidr, ticketing]

--- a/workflows/InsightIDR_Disable_User_in_Active_Directory/workflow.spec.yaml
+++ b/workflows/InsightIDR_Disable_User_in_Active_Directory/workflow.spec.yaml
@@ -7,14 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- insightidr
-- ldap
-- ad
-- activedirectory
-- user
-- disable
-- deprovision
 hub_tags:
   use_cases: [soar, soc_automation, user_management, siem, threat_detection_and_response]
   keywords: [insightidr, ldap, ad, activedirectory, user, disable, deprovision]

--- a/workflows/InsightIDR_Enable_User_in_Active_Directory/workflow.spec.yaml
+++ b/workflows/InsightIDR_Enable_User_in_Active_Directory/workflow.spec.yaml
@@ -7,12 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- insightidr
-- ldap
-- active_directory
-- enable
-- user_management
 hub_tags:
   use_cases: [soar, siem, user_management, threat_detection_and_response, soc_automation]
   keywords: [insightidr, ldap, ad, active_directory]

--- a/workflows/InsightIDR_Enrich_Alert_Data_with_Open_Source_Plugins/workflow.spec.yaml
+++ b/workflows/InsightIDR_Enrich_Alert_Data_with_Open_Source_Plugins/workflow.spec.yaml
@@ -7,12 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- insightidr
-- enrichment
-- analysis
-- hash
-- domain
 hub_tags:
   use_cases: [soar, soc_automation, siem, threat_detection_and_response, threat_intel]
   keywords: [insightidr, enrichment, analysis, hash, domain]

--- a/workflows/InsightIDR_Isolate_Sensor_in_Cb_Response/workflow.spec.yaml
+++ b/workflows/InsightIDR_Isolate_Sensor_in_Cb_Response/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- cb response
-- isolate
-- insightidr
 hub_tags:
   use_cases: [soar, soc_automation, siem, detection_and_response, threat_detection_and_response]
   keywords: [cb_response, isolate, insightidr]

--- a/workflows/InsightIDR_Suspend_User_in_Okta/workflow.spec.yaml
+++ b/workflows/InsightIDR_Suspend_User_in_Okta/workflow.spec.yaml
@@ -7,12 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- insightidr
-- okta
-- containment
-- deprovision
-- user
 hub_tags:
   use_cases: [user_management, soar, soc_automation, threat_detection_and_response]
   keywords: [insightidr, okta, containment, deprovision, user]

--- a/workflows/InsightIDR_Unisolate_Sensor_in_Cb_Response/workflow.spec.yaml
+++ b/workflows/InsightIDR_Unisolate_Sensor_in_Cb_Response/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- cb response
-- insightidr
-- remove isolation
 hub_tags:
   use_cases: [soar, soc_automation, siem, threat_detection_and_response]
   keywords: [cb Response, insightidr, remove isolation]

--- a/workflows/InsightIDR_Unsuspend_User_in_Okta/workflow.spec.yaml
+++ b/workflows/InsightIDR_Unsuspend_User_in_Okta/workflow.spec.yaml
@@ -7,13 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- insightidr
-- okta
-- containment
-- deprovision
-- user
-- remove suspension
 hub_tags:
   use_cases: [user_management, soar, soc_automation, threat_detection_and_response]
   keywords: [insightidr, okta, containment, deprovision, user, remove suspension]

--- a/workflows/Look_Up_Domains_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_Domains_with_Recorded_Future/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- enrichment
-- recorded future
-- domain
 hub_tags:
   use_cases: [soar, threat_intel, soc_automation]
   keywords: [enrichment, recorded future, domain]

--- a/workflows/Look_Up_Hashes_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_Hashes_with_Recorded_Future/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- enrichment
-- recorded future
-- hash
 hub_tags:
   use_cases: [soar, threat_intel, soc_automation]
   keywords: [enrichment, recorded future, hash]

--- a/workflows/Look_Up_IPs_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_IPs_with_Recorded_Future/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- enrichment
-- recorded future
-- ip
 hub_tags:
   use_cases: [soar, soc_automation, threat_intel]
   keywords: [enrichment, recorded future, ip]

--- a/workflows/Look_Up_URLs_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_URLs_with_Recorded_Future/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- enrichment
-- recorded future
-- url
 hub_tags:
   use_cases: [soar, soc_automation, threat_intel]
   keywords: [enrichment, recorded future, url]

--- a/workflows/Malicious_Hash_Remediation_with_Cb_Response/workflow.spec.yaml
+++ b/workflows/Malicious_Hash_Remediation_with_Cb_Response/workflow.spec.yaml
@@ -7,11 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- cb
-- hash
-- insightidr
-- carbonblack
 hub_tags:
   use_cases: [soar, soc_automation, asset_containment, threat_detection_and_response]
   keywords: [cb, hash, insightidr]

--- a/workflows/Microsoft_Teams_URL_Analysis/workflow.spec.yaml
+++ b/workflows/Microsoft_Teams_URL_Analysis/workflow.spec.yaml
@@ -7,11 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- microsoft_teams
-- teams
-- virustotal
-- chat
 hub_tags:
   use_cases: [soar, soc_automation, chat_ops, threat_intel]
   keywords: [chat, microsoft_teams, teams, virustotal]

--- a/workflows/Office_365_Analysis/workflow.spec.yaml
+++ b/workflows/Office_365_Analysis/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- phishing
-- email
-- office365
 hub_tags:
   use_cases: [soar, phishing_investigations, soc_automation, threat_intel]
   keywords: [phishing, email, office365]

--- a/workflows/Office_365_Analysis_with_Palo_Alto_Wildfire/workflow.spec.yaml
+++ b/workflows/Office_365_Analysis_with_Palo_Alto_Wildfire/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- phishing
-- email
-- office365
 hub_tags:
   use_cases: [soar, soc_automation, phishing_investigations, threat_intel]
   keywords: [phishing, email, office365]

--- a/workflows/Office_365_Analysis_with_Virus_Total/workflow.spec.yaml
+++ b/workflows/Office_365_Analysis_with_Virus_Total/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- phishing
-- email
-- office365
 hub_tags:
   use_cases: [soar, soc_automation, phishing_investigations, threat_intel]
   keywords: [phishing, email, office365]

--- a/workflows/Spearphishing_Remediation_with_Mimecast/workflow.spec.yaml
+++ b/workflows/Spearphishing_Remediation_with_Mimecast/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- phishing
-- email
-- mimecast
 hub_tags:
   use_cases: [soar, soc_automation, phishing_investigations, threat_intel]
   keywords: [phishing, email]

--- a/workflows/Spearphishing_Remediation_with_Office_365/workflow.spec.yaml
+++ b/workflows/Spearphishing_Remediation_with_Office_365/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- phishing
-- email
-- office365
 hub_tags:
   use_cases: [soar, soc_automation, phishing_investigations, threat_intel]
   keywords: [phishing, email]

--- a/workflows/Splunk_App_SSH_Alert_IP_Enrichment/workflow.spec.yaml
+++ b/workflows/Splunk_App_SSH_Alert_IP_Enrichment/workflow.spec.yaml
@@ -7,10 +7,6 @@ version: 1.0.0
 vendor: rapid7
 support: rapid7
 status: []
-tags:
-- phishing
-- email
-- office365
 hub_tags:
   use_cases: [soar, soc_automation, threat_intel, siem]
   keywords: [phishing, email, office365]


### PR DESCRIPTION
## Description

  - Remove tags field from all specs. This is only required in plugin specs because InsightConnect depends on it.

## Testing

```
$ for i in */workflow.spec.yaml; do js-yaml $i 1>/dev/null || printf "${i}\n"; done && printf "Good"
Good
```