### PR TITLE
Set new IDR workflows to both insightconnect and insightidr

### DIFF
--- a/workflows/Look_Up_Domains_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_Domains_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-products: ["insightconnect"]
+products: [insightconnect, insightidr]
 name: Look_Up_Domains_with_Recorded_Future
 title: "Look Up Domains with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all domains in the investigation with Recorded Future."

--- a/workflows/Look_Up_Hashes_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_Hashes_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-products: ["insightconnect"]
+products: [insightconnect, insightidr]
 name: Look_Up_Hashes_with_Recorded_Future
 title: "Look Up Hashes with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all hashes in the investigation with Recorded Future."

--- a/workflows/Look_Up_IPs_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_IPs_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-products: ["insightconnect"]
+products: [insightconnect, insightidr]
 name: Look_Up_IPs_with_Recorded_Future
 title: "Look Up IPs with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all IPs in the investigation with Recorded Future."

--- a/workflows/Look_Up_URLs_with_Recorded_Future/workflow.spec.yaml
+++ b/workflows/Look_Up_URLs_with_Recorded_Future/workflow.spec.yaml
@@ -1,5 +1,5 @@
 extension: workflow
-products: ["insightconnect"]
+products: [insightconnect, insightidr]
 name: Look_Up_URLs_with_Recorded_Future
 title: "Look Up URLs with Recorded Future"
 description: "This workflow enriches an IDR alert by performing a lookup on all URLs in the investigation with Recorded Future."


### PR DESCRIPTION
## Requirements

* Add `insightidr` to product listing for the later IDR workflows after a discussion about them. They're valid for both products.

## Testing

```
$ for i in InsightIDR*; do js-yaml $i/workflow.spec.yaml 1>/dev/null || printf "Failed\n"; done && printf "Done\n"
Done
```