### PR TITLE
Change O365 to Office 365

### DIFF
--- a/workflows/Delete_O365_Emails_with_Slack/Delete_O365_Emails_With_Slack.icon
+++ b/workflows/Delete_O365_Emails_with_Slack/Delete_O365_Emails_With_Slack.icon
@@ -5,7 +5,7 @@
     "exportedAt": "2020-04-07T17:15:42.958451022Z",
     "workflowVersions": [
       {
-        "name": "Delete O365 Emails With Slack",
+        "name": "Delete Office 365 Emails With Slack",
         "type": "runnable",
         "version": "",
         "description": "This workflow will delete emails matching given search criteria by sending a notification to InisghtConnect with Slack. The workflow will look for any emails that match the body, subject, for from contents given. It can either automatically delete these emails or prompt the user for further action.",

--- a/workflows/Delete_O365_Emails_with_Slack/workflow.spec.yaml
+++ b/workflows/Delete_O365_Emails_with_Slack/workflow.spec.yaml
@@ -1,7 +1,7 @@
 extension: workflow
 products: ["insightconnect"]
 name: Delete_O365_Emails_With_Slack
-title: "Delete O365 Emails With Slack"
+title: "Delete Office 365 Emails With Slack"
 description: "This workflow will delete emails matching given search criteria by sending a notification to InisghtConnect with Slack."
 version: 1.0.1
 vendor: rapid7


### PR DESCRIPTION
## Description 

In the Delete_O365_Emails_With_Slack directory, need to change the title of the workflow to Office 365 instead of O365 for consistent naming. 

## Testing: 
Imported the workflow into ICON to verify it could be imported and the name was correct. 