### PR TITLE
updated plugin in Purge with Teams

### DIFF
--- a/workflows/Purge_Office_365_Emails_with_Microsoft_Teams/Purge_Office_365_Emails_with_Microsoft_Teams.icon
+++ b/workflows/Purge_Office_365_Emails_with_Microsoft_Teams/Purge_Office_365_Emails_with_Microsoft_Teams.icon
@@ -252,8 +252,8 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+              "slugVersion": "2.0.2",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
             },
             "identifier": "send_html_message",
             "continueOnFailure": false,
@@ -508,8 +508,8 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+              "slugVersion": "2.0.2",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
             },
             "identifier": "send_html_message",
             "continueOnFailure": false,
@@ -696,7 +696,7 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
+              "slugVersion": "2.0.2",
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
             },
             "identifier": "send_html_message",
@@ -1042,8 +1042,8 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+              "slugVersion": "2.0.2",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
             },
             "identifier": "send_html_message",
             "continueOnFailure": false,
@@ -1242,8 +1242,8 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+              "slugVersion": "2.0.2",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
             },
             "identifier": "send_html_message",
             "continueOnFailure": false,
@@ -1412,8 +1412,8 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+              "slugVersion": "2.0.2",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
             },
             "identifier": "new_message_received",
             "continueOnFailure": false,
@@ -1705,8 +1705,8 @@
               "name": "Microsoft Teams",
               "slugVendor": "rapid7",
               "slugName": "microsoft_teams",
-              "slugVersion": "2.0.1",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+              "slugVersion": "2.0.2",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
             },
             "identifier": "send_html_message",
             "continueOnFailure": false,
@@ -2095,8 +2095,8 @@
           "name": "Microsoft Teams",
           "slugVendor": "rapid7",
           "slugName": "microsoft_teams",
-          "slugVersion": "2.0.1",
-          "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.1/icon.png"
+          "slugVersion": "2.0.2",
+          "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/microsoft_teams/2.0.2/icon.png"
         }
       }
     ]

--- a/workflows/Purge_Office_365_Emails_with_Microsoft_Teams/help.md
+++ b/workflows/Purge_Office_365_Emails_with_Microsoft_Teams/help.md
@@ -45,7 +45,7 @@ Plugins utilized by workflow:
 
 |Plugin|Version|Count|
 |----|----|--------|
-|Microsoft Teams|2.0.1|7|
+|Microsoft Teams|2.0.2|7|
 |Microsoft Office365 Email Security|2.2.1|2|
 |Python 3 Script|2.0.1|2|
 |HTML|1.2.1|1|
@@ -56,6 +56,7 @@ _There is no troubleshooting information at this time_
 
 # Version History
 
+* 1.0.1 - Update to Microsoft Teams 2.0.2
 * 1.0.0 - Initial workflow
 
 # Links

--- a/workflows/Purge_Office_365_Emails_with_Microsoft_Teams/workflow.spec.yaml
+++ b/workflows/Purge_Office_365_Emails_with_Microsoft_Teams/workflow.spec.yaml
@@ -3,7 +3,7 @@ products: ["insightconnect"]
 name: Purge_Office_365_Emails_with_Microsoft_Teams
 title: "Purge Office 365 Emails with Microsoft Teams"
 description: "This workflow will delete all emails matching given search criteria from an organization using a command issued from Microsoft Teams."
-version: 1.0.0
+version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []


### PR DESCRIPTION
## Description

This PR updates the Purge with Microsoft Teams workflow to the Microsoft Teams 2.0.2 plugin

## Validation
```
rmt-mbp-5357:Purge_Office_365_Emails_with_Microsoft_Teams jmcadams$ icon-validate .
[*] Validating workflow at .

[*] Running Integration Validators...
[*] Executing validator WorkflowDirectoryNameMatchValidator
[*] Executing validator WorkflowFilesValidator
[*] Executing validator WorkflowHelpValidator
[*] Executing validator WorkflowChangelogValidator
[*] Executing validator WorkflowVendorValidator
[*] Executing validator WorkflowVersionValidator
[*] Executing validator WorkflowExtensionValidator
[*] Executing validator WorkflowSupportValidator
[*] Executing validator WorkflowPNGHashValidator
[*] Executing validator WorkflowICONFileNameValidator
[*] Executing validator WorkflowScreenshotValidator
[*] Executing validator WorkflowTitleValidator
[*] Executing validator WorkflowDescriptionValidator
[*] Executing validator WorkflowNameValidator
[*] Executing validator WorkflowProfanityValidator
[*] Executing validator WorkflowHelpPluginUtilizationValidator
[*] Executing validator WorkflowICONFileValidator
[*] Workflow successfully validated!

----
[*] Total time elapsed: 33.543000000000006ms
```

## Testing: 
Updated the plugin, imported to ICON, verified the Flow was still triggered appropriately. 
