### PR TITLE
Fixed vuln_db version in Lookup Vuln From Teams workflow

### DIFF
--- a/workflows/Lookup_Vuln_From_Teams/Lookup_Vuln_From_Teams.icon
+++ b/workflows/Lookup_Vuln_From_Teams/Lookup_Vuln_From_Teams.icon
@@ -1424,8 +1424,8 @@
               "name": "Rapid7 Vulnerability & Exploit Database",
               "slugVendor": "rapid7",
               "slugName": "rapid7_vulndb",
-              "slugVersion": "2.0.4",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/rapid7_vulndb/2.0.4/icon.png"
+              "slugVersion": "2.0.3",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/rapid7_vulndb/2.0.3/icon.png"
             },
             "identifier": "get_content",
             "continueOnFailure": false,
@@ -1791,8 +1791,8 @@
               "name": "Rapid7 Vulnerability & Exploit Database",
               "slugVendor": "rapid7",
               "slugName": "rapid7_vulndb",
-              "slugVersion": "2.0.4",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/rapid7_vulndb/2.0.4/icon.png"
+              "slugVersion": "2.0.3",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/rapid7_vulndb/2.0.3/icon.png"
             },
             "identifier": "get_content",
             "continueOnFailure": false,
@@ -1924,8 +1924,8 @@
               "name": "Rapid7 Vulnerability & Exploit Database",
               "slugVendor": "rapid7",
               "slugName": "rapid7_vulndb",
-              "slugVersion": "2.0.4",
-              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/rapid7_vulndb/2.0.4/icon.png"
+              "slugVersion": "2.0.3",
+              "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/rapid7_vulndb/2.0.3/icon.png"
             },
             "identifier": "search_db",
             "continueOnFailure": false,

--- a/workflows/Lookup_Vuln_From_Teams/help.md
+++ b/workflows/Lookup_Vuln_From_Teams/help.md
@@ -46,7 +46,7 @@ Plugins utilized by workflow:
 |----|----|--------|
 |Microsoft Teams|2.0.4|6|
 |HTML|1.2.1|1|
-|Rapid7 Vulnerability & Exploit Database|2.0.4|3|
+|Rapid7 Vulnerability & Exploit Database|2.0.3|3|
 |Type Converter|1.5.1|2|
 |Basename|1.0.1|2|
 |URL Extractor|1.0.3|1|
@@ -57,6 +57,7 @@ _There is no troubleshooting information at this time_
 
 # Version History
 
+* 1.0.2 - Fix to correct invalid version of Rapid7 Vulnerability & Exploit Database
 * 1.0.1 - Update to make Microsoft Teams plugin the latest version
 * 1.0.0 - Initial workflow
 

--- a/workflows/Lookup_Vuln_From_Teams/workflow.spec.yaml
+++ b/workflows/Lookup_Vuln_From_Teams/workflow.spec.yaml
@@ -3,7 +3,7 @@ products: ["insightconnect", "insightvm"]
 name: Lookup_Vuln_From_Teams
 title: "Lookup Vulnerability from Microsoft Teams"
 description: This workflow accepts a Microsoft Teams command, looks up the vulnerability in Rapid7's vulnerability database, and posts the vulnerability details back to the same Teams channel.
-version: 1.0.1
+version: 1.0.2
 vendor: rapid7
 support: rapid7
 status: []


### PR DESCRIPTION
## Requirements

This PR fixes an invalid version of the vuln_db plugin in the Lookup_Vlun_From_Teams workflow. 

## Testing: 

Workflow was imported into ICON successfully. 