### PR TITLE
Changed continue on failure flag to true for scan step

### DIFF
--- a/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack.icon
+++ b/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack.icon
@@ -546,7 +546,7 @@
               "imageData": "https://us.cdn-assets.connect.insight.rapid7.com/icons/rapid7/virustotal/6.0.3/icon.png"
             },
             "identifier": "scan_url_report",
-            "continueOnFailure": false,
+            "continueOnFailure": true,
             "isDisabled": false,
             "isCloud": false,
             "parameters": {

--- a/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack/help.md
+++ b/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack/help.md
@@ -60,6 +60,7 @@ _There is no troubleshooting information at this time_
 
 # Version History
 
+* 1.1.1 - Set continue on scan fail to true
 * 1.1.0 - Add automatic indicator extraction
 * 1.0.5 - Updated trigger syntax and documentation
 * 1.0.4 - Updated documentation

--- a/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack/workflow.spec.yaml
+++ b/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack/workflow.spec.yaml
@@ -3,7 +3,7 @@ products: ["insightconnect"]
 name: Enrich_URLs_and_Domains_with_VirusTotal_from_Slack
 title: "Enrich URLs and Domains with VirusTotal from Slack"
 description: Enrich potential indicators of compromise by getting VirusTotal reports for URLs and domains with a Slack command.
-version: 1.1.0
+version: 1.1.1
 vendor: rapid7
 support: rapid7
 status: []


### PR DESCRIPTION
## Proposed changes

* Change "continueOnFailure" field to true in enrichment workflow
* Allows the user to hit the URL Scan Failure branch

### Screenshot

<img width="1639" alt="Screen Shot 2020-08-27 at 3 37 10 PM" src="https://user-images.githubusercontent.com/69209594/91487297-8a789080-e87b-11ea-86bd-75e52025d756.png">


## Validation

```
ncramer@BOS-MBP-8176:~/go/src/github.com/rapid7/insightconnect-workflows/workflows/Enrich_URLs_and_Domains_with_VirusTotal_from_Slack|continue-on-fail-update ⇒  icon-validate .
[*] Validating workflow at .

[*] Running Integration Validators...
[*] Executing validator WorkflowDirectoryNameMatchValidator
[*] Executing validator WorkflowFilesValidator
[*] Executing validator WorkflowHelpValidator
[*] Executing validator WorkflowChangelogValidator
[*] Executing validator WorkflowVendorValidator
[*] Executing validator WorkflowVersionValidator
[*] Executing validator WorkflowExtensionValidator
[*] Executing validator WorkflowSupportValidator
[*] Executing validator WorkflowPNGHashValidator
[*] Executing validator WorkflowICONFileNameValidator
[*] Executing validator WorkflowScreenshotValidator
[*] Executing validator WorkflowTitleValidator
[*] Executing validator WorkflowDescriptionValidator
[*] Executing validator WorkflowNameValidator
[*] Executing validator WorkflowProfanityValidator
[*] Executing validator WorkflowHelpPluginUtilizationValidator
[*] Executing validator WorkflowICONFileValidator
[*] Workflow successfully validated!

----
[*] Total time elapsed: 25.628999999999998ms
```