### PR TITLE
added cloud_enabled tags

### DIFF
--- a/workflows/Artifact_Examples/workflow.spec.yaml
+++ b/workflows/Artifact_Examples/workflow.spec.yaml
@@ -9,7 +9,7 @@ support: community
 status: []
 hub_tags:
   use_cases: [data_utility]
-  keywords: [example]
+  keywords: [example, cloud_enabled]
   features: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-workflows/tree/master/workflows/Artifact_Examples

--- a/workflows/Enrich_URL_with_Threat_Crowd_from_Slack/workflow.spec.yaml
+++ b/workflows/Enrich_URL_with_Threat_Crowd_from_Slack/workflow.spec.yaml
@@ -9,7 +9,7 @@ support: rapid7
 status: []
 hub_tags:
   use_cases: [data_enrichment, threat_detection_and_response]
-  keywords: [slack, chat, chatops, work_from_home]
+  keywords: [slack, chat, chatops, work_from_home, cloud_enabled]
   features: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-workflows/tree/master/workflows/Enrich_URL_with_Threat_Crowd_from_Slack

--- a/workflows/Hello_IDR_Alert/workflow.spec.yaml
+++ b/workflows/Hello_IDR_Alert/workflow.spec.yaml
@@ -6,7 +6,7 @@ description: Learn to use the InsightIDR UBA Alert Trigger.
 version: 1.0.0
 vendor: rapid7
 support: rapid7
-status: [obsolete]
+status: []
 hub_tags:
   use_cases: [threat_detection_and_response]
   keywords: [cloud_enabled]

--- a/workflows/Hello_IDR_Alert/workflow.spec.yaml
+++ b/workflows/Hello_IDR_Alert/workflow.spec.yaml
@@ -9,7 +9,7 @@ support: rapid7
 status: []
 hub_tags:
   use_cases: [threat_detection_and_response]
-  keywords: [cloud-enabled]
+  keywords: [cloud_enabled]
   features: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-workflows/tree/master/workflows/Hello_IDR_Alert

--- a/workflows/Hello_IDR_Alert/workflow.spec.yaml
+++ b/workflows/Hello_IDR_Alert/workflow.spec.yaml
@@ -6,7 +6,7 @@ description: Learn to use the InsightIDR UBA Alert Trigger.
 version: 1.0.0
 vendor: rapid7
 support: rapid7
-status: []
+status: [obsolete]
 hub_tags:
   use_cases: [threat_detection_and_response]
   keywords: [cloud_enabled]

--- a/workflows/Hello_World/workflow.spec.yaml
+++ b/workflows/Hello_World/workflow.spec.yaml
@@ -6,7 +6,7 @@ description: Learn how to use InsightConnect!
 version: 1.0.0
 vendor: rapid7
 support: rapid7
-status: [obsolete]
+status: []
 hub_tags:
   use_cases: []
   keywords: [cloud_enabled]

--- a/workflows/Hello_World/workflow.spec.yaml
+++ b/workflows/Hello_World/workflow.spec.yaml
@@ -9,7 +9,7 @@ support: rapid7
 status: []
 hub_tags:
   use_cases: []
-  keywords: []
+  keywords: [cloud_enabled]
   features: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-workflows/tree/master/workflows/Hello_World

--- a/workflows/Hello_World/workflow.spec.yaml
+++ b/workflows/Hello_World/workflow.spec.yaml
@@ -6,7 +6,7 @@ description: Learn how to use InsightConnect!
 version: 1.0.0
 vendor: rapid7
 support: rapid7
-status: []
+status: [obsolete]
 hub_tags:
   use_cases: []
   keywords: [cloud_enabled]


### PR DESCRIPTION
Adding the cloud-enabled keyword tag to all workflows that currently use IDR or Slack trigger and cloud_enabled plugins.

This will be a temporary solution so that we can easily display plugins & workflows that may be run on the cloud in the Extension Library.

