### PR TITLE
Fix change_me typo in Parse_Phishing_Indicators_with_Gmail_from_Slack

### DIFF
--- a/workflows/Parse_Phishing_Indicators_with_Gmail_from_Slack/Parse_Phishing_Indicators_with_Gmail_from_Slack.icon
+++ b/workflows/Parse_Phishing_Indicators_with_Gmail_from_Slack/Parse_Phishing_Indicators_with_Gmail_from_Slack.icon
@@ -632,7 +632,7 @@
               "input": {
                 "attachments": [],
                 "message": "📨  Email Received: Beginning Analysis 📨\n\nFrom: {{[a87bab8a-835c-4cec-ae7c-68dab0355e9f].[email].[sender]}}\nSubject: {{[a87bab8a-835c-4cec-ae7c-68dab0355e9f].[email].[subject]}}",
-                "recipient": "#chamge_me",
+                "recipient": "change_me",
                 "thread_ts": ""
               }
             },

--- a/workflows/Parse_Phishing_Indicators_with_Gmail_from_Slack/help.md
+++ b/workflows/Parse_Phishing_Indicators_with_Gmail_from_Slack/help.md
@@ -39,6 +39,7 @@ _There is no troubleshooting information at this time_
 
 # Version History
 
+* 1.0.1 - Fix change_me typo in Slack `recipient` input field
 * 1.0.0 - Initial workflow
 
 # Links

--- a/workflows/Parse_Phishing_Indicators_with_Gmail_from_Slack/workflow.spec.yaml
+++ b/workflows/Parse_Phishing_Indicators_with_Gmail_from_Slack/workflow.spec.yaml
@@ -3,7 +3,7 @@ products: ["insightconnect"]
 name: Parse_Phishing_Indicators_with_Gmail_from_Slack
 title: "Parse Phishing Indicators with Gmail from Slack"
 description: "This workflow will dissect an email and return all potential malicious indicators to Slack in a message."
-version: 1.0.0
+version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []


### PR DESCRIPTION
## Description

Fix typo `#chamge_me` to `change_me` in workflow